### PR TITLE
Depend on Alien::GMP to automatically install GMP

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 Revision history for Perl extension Math::GMP.
+    - Depend on Alien::GMP to automatically install GMP when missing
 
 2.17  2018-04-05 Shlomif
     - Correct the link to the GitHub repository.

--- a/INSTALL
+++ b/INSTALL
@@ -1,11 +1,17 @@
 Math::GMP - High speed arbitrary size integer math
 
-To install this package, you will need a version of the GMP library. You can
-get it at the homepage of GMP:
+To install this package, you will need a version of the GMP library. You
+have different alternatives:
+
+- get it at the homepage of GMP:
 
 	http://www.gmplib.org/
 
-After installing GMP, do the following:
+- install a pre-compiled package provided by your distribution
+
+- let Math::GMP download and install GMP for you (thanks to Alien::GMP)
+
+After installing GMP (if you want to do it yourself), do the following:
 
 	perl Makefile.PL
 	make

--- a/dist.ini
+++ b/dist.ini
@@ -11,11 +11,11 @@ copyright_year   = 2000
 -remove = License
 -remove = Readme
 [AutoPrereqs]
-[CheckLib]
-lib = gmp
-header = gmp.h
+[Prereqs / ConfigureRequires]
+Alien::GMP = 1.08
 [MakeMaker::Awesome]
-WriteMakefile_arg = 'LIBS' => ['-lgmp'],
+header = use Alien::Base::Wrapper qw( Alien::GMP !export );
+WriteMakefile_arg = Alien::Base::Wrapper->mm_args
 [MetaJSON]
 [MetaProvides::Package]
 [MetaResources]


### PR DESCRIPTION
With reference to [RT#125018](https://rt.cpan.org/Ticket/Display.html?id=125018) and to the best of my knowledge, this adds a dependency on [Alien::GMP](https://metacpan.org/pod/Alien::GMP) to automatically download, compile and install GMP if missing. Related issue: [https://github.com/rsimoes/Alien-GMP/issues/6](https://github.com/rsimoes/Alien-GMP/issues/6).

I tried it successfully in both the following conditions:
- with an already existing installation of GMP (correctly pointing to the "system" instance), and 
- without it in a clean environment (in which case, GMP was downloaded, installed and correctly used by Math::GMP).