### PR TITLE
Provide XS code for bool overload

### DIFF
--- a/GMP.xs
+++ b/GMP.xs
@@ -295,6 +295,19 @@ mod_2exp_gmp(in, cnt)
     RETVAL
 
 
+SV *
+op_bool(m,n,swap)
+	mpz_t *		m
+	mpz_t *		n
+	bool		swap
+
+  CODE:
+	/* n is dummy variable for unary op */
+	RETVAL = mpz_sgn(*m) ? &PL_sv_yes : &PL_sv_no;
+  OUTPUT:
+    RETVAL
+
+
 mpz_t *
 op_add(m,n,swap)
 	mpz_t *		m

--- a/lib/Math/GMP.pm
+++ b/lib/Math/GMP.pm
@@ -35,7 +35,7 @@ use vars qw(@ISA @EXPORT @EXPORT_OK $AUTOLOAD);
 use overload (
 	'""'  =>   sub { stringify($_[0]) },
 	'0+'  =>   sub { $_[0] >= 0 ? uintify($_[0]) : intify($_[0]) },
-	'bool' =>  sub { $_[0] != 0 },
+	'bool' =>  \&op_bool,
 
 	'<=>' =>   \&op_spaceship,
 	'=='  =>   \&op_eq,


### PR DESCRIPTION
In a profile, I happened to notice these adjacent lines implying that the bool override was over ten times slower than addition:
```
# spent  4.32s making  1823104 calls to Math::GMP::__ANON__[Math/GMP.pm:38], avg 2µs/call
# spent  2.00s making  9115520 calls to Math::GMP::op_add, avg 219ns/call
```

Benchmark doesn't show it 10x slower, but does demonstrate the improvement before/after this PR:
```
# installed v2.24
% perl -MMath::GMP -MBenchmark=cmpthese -E '$z1 = Math::GMP->new(1);
  cmpthese(-1, { "not" => q{ !$::z1; }, add => q{ $::z1 + $::z1 } })'
         Rate  not  add
not 2572440/s   -- -18%
add 3143931/s  22%   --
# uninstalled v2.24 + this commit
% perl -Iblib/lib -Iblib/arch -MMath::GMP -MBenchmark=cmpthese -E '$z1 = Math::GMP->new(1);
  cmpthese(-1, { "not" => q{ !$::z1; }, add => q{ $::z1 + $::z1 } })'
          Rate  add  not
add  2998379/s   -- -72%
not 10794164/s 260%   --
% 
```

There are already tests for bool, so I didn't add more.