### PR TITLE
hv/convert ops

### DIFF
--- a/GMP.xs
+++ b/GMP.xs
@@ -101,6 +101,21 @@ sv2gmp(SV* sv)
 }
 
 
+SV *
+stringify(mpz_t *n)
+{
+	char* pv;
+    int len = mpz_sizeinbase(*n, 10);
+	char *buf = malloc(len + 2);
+	SV *sv;
+
+	mpz_get_str(buf, 10, *n);
+	sv = newSVpv(buf, strlen(buf));
+	free(buf);
+	return sv;
+}
+
+
 MODULE = Math::GMP		PACKAGE = Math::GMP
 PROTOTYPES: ENABLE
 
@@ -157,18 +172,8 @@ SV *
 stringify(n)
 	mpz_t *	n
 
-  PREINIT:
-    int len;
-
   CODE:
-    len = mpz_sizeinbase(*n, 10);
-    {
-      char *buf;
-      buf = malloc(len + 2);
-      mpz_get_str(buf, 10, *n);
-      RETVAL = newSVpv(buf, strlen(buf));
-      free(buf);
-    }
+    RETVAL = stringify(n);
   OUTPUT:
     RETVAL
 
@@ -291,6 +296,49 @@ mod_2exp_gmp(in, cnt)
     RETVAL = malloc (sizeof(mpz_t));
     mpz_init(*RETVAL);
     mpz_mod_2exp(*RETVAL, *in, cnt);
+  OUTPUT:
+    RETVAL
+
+
+SV *
+op_stringify(m,n,swap)
+	mpz_t *		m
+	SV *		n
+	bool		swap
+
+  CODE:
+	/* 'n' and 'swap' are dummy variables */
+	RETVAL = stringify(m);
+  OUTPUT:
+    RETVAL
+
+
+SV *
+op_numify(m,n,swap)
+	mpz_t *		m
+	SV *		n
+	bool		swap
+
+  CODE:
+	/* 'n' and 'swap' are dummy variables */
+	if (mpz_sgn(*m) < 0) {
+		RETVAL = newSViv(mpz_get_si(*m));
+	} else {
+		RETVAL = newSVuv(mpz_get_ui(*m));
+	}
+  OUTPUT:
+    RETVAL
+
+
+SV *
+op_bool(m,n,swap)
+	mpz_t *		m
+	SV *		n
+	bool		swap
+
+  CODE:
+	/* 'n' and 'swap' are dummy variables */
+	RETVAL = mpz_sgn(*m) ? &PL_sv_yes : &PL_sv_no;
   OUTPUT:
     RETVAL
 

--- a/lib/Math/GMP.pm
+++ b/lib/Math/GMP.pm
@@ -33,9 +33,9 @@ use Carp;
 use vars qw(@ISA @EXPORT @EXPORT_OK $AUTOLOAD);
 
 use overload (
-	'""'  =>   sub { stringify($_[0]) },
-	'0+'  =>   sub { $_[0] >= 0 ? uintify($_[0]) : intify($_[0]) },
-	'bool' =>  sub { $_[0] != 0 },
+	'""'  =>   \&op_stringify,
+	'0+'  =>   \&op_numify,
+	'bool' =>  \&op_bool,
 
 	'<=>' =>   \&op_spaceship,
 	'=='  =>   \&op_eq,

--- a/t/01_gmppm.t
+++ b/t/01_gmppm.t
@@ -16,7 +16,7 @@ plan tests => (2 * @tests + 10);
 my $WITH_FEATURE = ("$]" >= 5.022);
 
 # work around Test::Builder bug if needed
-monkey_patch();
+monkey_patch() if $Test::More::VERSION < 1.302189;
 
 LINES:
 foreach my $line (@data) {
@@ -275,7 +275,7 @@ foreach my $line (@data) {
 # all done
 
 #
-# At least up to v1.302164, Test::Builder::_unoverload() tries to invoke
+# Until v1.302189, Test::Builder::_unoverload() tries to invoke
 # an overload method wrongly. We try it here, and if it fails we monkey
 # patch it to a version that should work.
 #

--- a/t/01_gmppm.t
+++ b/t/01_gmppm.t
@@ -15,6 +15,9 @@ plan tests => (2 * @tests + 10);
 
 my $WITH_FEATURE = ("$]" >= 5.022);
 
+# work around Test::Builder bug if needed
+monkey_patch();
+
 LINES:
 foreach my $line (@data) {
 	chomp $line;
@@ -270,6 +273,39 @@ foreach my $line (@data) {
 }
 
 # all done
+
+#
+# At least up to v1.302164, Test::Builder::_unoverload() tries to invoke
+# an overload method wrongly. We try it here, and if it fails we monkey
+# patch it to a version that should work.
+#
+sub monkey_patch {
+	my $tb = Test::Builder->new;
+	my $z = Math::GMP->new(17);
+	eval { $tb->_unoverload(q{""}, \$z) };
+
+	# do nothing if it worked: $z should have been replaced with its string
+	return if !$@ && $z eq '17' && !ref($z);
+
+	# patch if it failed
+	use Scalar::Util qw{ blessed };
+	no warnings qw{ redefine };
+	*Test::Builder::_unoverload = sub {
+		my ($self, $type, $thing) = @_;
+		return unless ref $$thing;
+		return unless blessed($$thing) || scalar $self->_try(sub{ $$thing->isa('UNIVERSAL') });
+		{
+	        local ($!, $@);
+        	require overload;
+    	}
+    	my $string_meth = overload::Method( $$thing, $type ) || return;
+
+		# this is the fix - the interface requires two args passed in
+		#$$thing = $$thing->$string_meth();
+    	$$thing = $$thing->$string_meth(undef, 0);
+	};
+	return;
+}
 
 __END__
 &bcmp


### PR DESCRIPTION
Here's the proposed change for discussion. I've added a commit to monkey-patch the Test::Builder problem (https://github.com/Test-More/test-more/issues/890), but would prefer to wait for a fix there so we can at least put a version guard on the patch.

Benchmark:

```
perl -Iblib/lib -Iblib/arch -MBenchmark=timethese -MMath::GMP -we '
  our $z = Math::GMP->new(1);
  our @a = (0,1);
  timethese(-1, {
    stringify => q{ my $r = "$::z" },
    numify => q{ my $r = $::a[$::z] },
    boolify => q{ my $r = !$::z },
  })'

# before:
   boolify:  1 wallclock secs ( 1.03 usr +  0.00 sys =  1.03 CPU) @ 2226951.46/s (n=2293760)
    numify:  1 wallclock secs ( 1.02 usr +  0.00 sys =  1.02 CPU) @ 2075800.00/s (n=2117316)
 stringify:  1 wallclock secs ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 4327848.11/s (n=4587519)
# after:
   boolify:  1 wallclock secs ( 1.07 usr +  0.00 sys =  1.07 CPU) @ 8574803.74/s (n=9175040)
    numify:  1 wallclock secs ( 1.05 usr +  0.00 sys =  1.05 CPU) @ 8065968.57/s (n=8469267)
 stringify:  1 wallclock secs ( 1.04 usr +  0.00 sys =  1.04 CPU) @ 5293291.35/s (n=5505023)
```